### PR TITLE
decode_supout: add /proc decoder, port to Python3

### DIFF
--- a/decode_supout.py
+++ b/decode_supout.py
@@ -1,69 +1,159 @@
-#!/usr/bin/python
-# (C) Kirils Solovjovs, 2015
+#!/usr/bin/python3
+# (C) Kirils Solovjovs, 2015 - tribit()
+#     Leonid Evdokimov, 2024 - /proc archive
 
-import sys,os,base64,zlib,re
+import base64, errno, io, os, re, stat, struct, sys, zlib
 
-#           111111 11112222
-#01234567 89012345 67890123
-#cdefgh56 78abGH12 34ABCDEF  (from)
-#abcdefgh 12345678 ABCDEFGH  (to)
-#revtribitmap=[2,3,4,5,6,7,12,13,14,15,0,1,22,23,8,9,10,11,16,17,18,19,20,21]
-tribitmap=[10,11,0,1,2,3,4,5,14,15,16,17,6,7,8,9,18,19,20,21,22,23,12,13]
-
-def tribit(content):
-	#origlen=len(content)
-	#while len(content)%3:
-	#	content= content + "\x00"
-		
-	result=""
-	for i in xrange(0, len(content) - 1,3):	
-		goodtribit=0
-		badtribit=ord(content[i])*0x10000+ord(content[i+1])*0x100+ord(content[i+2])
-		for mangle in tribitmap:
-			goodtribit = (goodtribit<<1) + (1 if ((badtribit & (0x800000>>mangle))>0) else 0)
-			
-		for move in [16,8,0]:
-			result=result+chr((goodtribit >> move)& 0xff)
-
-	return result
-	#return result[0:origlen]
-
-if len(sys.argv) > 1:
-	if len(sys.argv) > 2:
-		dir = sys.argv[2]
-	else:
-		dir = sys.argv[1]+"_contents/"
-else:
-	raise Exception("Usage: "+sys.argv[0]+" <supout.rif> [output_folder]")
+#            111111 11112222
+# 01234567 89012345 67890123
+# cdefgh56 78abGH12 34ABCDEF  (from)
+# abcdefgh 12345678 ABCDEFGH  (to)
+# revtribitmap=[2,3,4,5,6,7,12,13,14,15,0,1,22,23,8,9,10,11,16,17,18,19,20,21]
+TRIBITMAP = [
+    10, 11,  0 , 1,  2,  3,  4,  5,
+    14, 15, 16, 17,  6,  7,  8,  9,
+    18, 19, 20, 21, 22, 23, 12, 13,
+]
 
 
-if not os.access(sys.argv[1], os.R_OK):
-	raise Exception("Can't read file "+sys.argv[1])
+def tribit(content: bytes):
+    out = bytes()
+    for i in range(0, len(content) - 1, 3):
+        raw = content[i : i + 3]
+        good = 0
+        bad = raw[0] * 0x10000 + raw[1] * 0x100 + raw[2]
+        for shift in TRIBITMAP:
+            good = (good << 1) + (1 if (bad & (0x800000 >> shift)) else 0)
+        out += bytes([(good >> 16) & 0xFF, (good >> 8) & 0xFF, good & 0xFF])
+    return out
 
-if not os.path.exists(dir):
-    os.makedirs(dir)
 
-if not os.access(dir, os.W_OK):
-	raise Exception("Directory "+dir+" not writeable")
-	
-if os.listdir(dir)!=[]:
-	raise Exception("Directory "+dir+" not empty")
+U32BE = struct.Struct(">I")
+U32LE = struct.Struct("<I")
 
-i=0
-with open(sys.argv[1], 'r') as my_file:
-    sections=my_file.read().replace("--BEGIN ROUTEROS SUPOUT SECTION\r\n",":").replace("--END ROUTEROS SUPOUT SECTION\r\n",":").replace("::",":").split(":")
-    for sect in sections:
-			if len(sect.strip())>0:
-				i= i + 1
-				
-				out = tribit(base64.b64decode(sect.replace("=","A")))
-				
-				[name,zipped]=out.split("\x00",1);
-				print '%02d' % i,name.ljust(23),
-				if not i%3:
-					print
-					
-				res=zlib.decompress(zipped)
-				fo = open(dir+"/"+str(i).zfill(2)+"_"+re.sub('[^a-z0-9\.-]','_',name), "wb")
-				fo.write(res);
-				fo.close()
+
+def itlv(fd, U32):
+    for tag in iter(lambda: fd.read(1), b""):
+        tag = int(tag[0])
+        length = U32.unpack(fd.read(U32.size))[0]
+        value = fd.read(length)
+        assert length == len(value), (length, len(value))
+        yield (tag, value)
+
+
+def mksubdir(prefix, tree):
+    dest = os.path.realpath(os.path.join(prefix, *tree))
+    if not dest.startswith(prefix + os.path.sep):
+        raise RuntimeError("Directory escape?", dest, prefix, tree)
+    os.mkdir(dest)
+
+
+def opensub(prefix, tree, *args, **kwargs):
+    dest = os.path.realpath(os.path.join(prefix, *tree))
+    if not dest.startswith(prefix + os.path.sep):
+        raise RuntimeError("Directory escape?", dest, prefix, tree)
+    return open(dest, *args, **kwargs)
+
+
+def parse_ar(prefix, blob, U32):
+    STAT, FNAME, DATA, MAGIC, END = 1, 2, 3, 4, 5  # END is both EOF & `..'
+    prefix += "_contents"
+    os.mkdir(prefix)
+
+    it = itlv(io.BytesIO(blob), U32)
+    t, v = next(it)
+    assert t == MAGIC and len(v) == U32.size and U32.unpack(v)[0] == 2, (t, v)
+    tree = []
+    for t, v in it:
+        if t == END:
+            assert not v and len(tree) > 0, (v, tree)
+            tree.pop()
+            continue
+
+        assert t == FNAME, t
+        fname = v.decode("ascii")
+
+        t, v = next(it)
+        if t == END and len(v) == U32.size:
+            fname = os.path.join(*tree, fname)
+            err = U32.unpack(v)[0]
+            errorcode = errno.errorcode.get(err)
+            print("==> ?????????? {:s} !!!! errno={:d} (maybe {:s})".format(fname, err, errorcode))
+            continue
+        assert t == STAT and len(v) == U32.size, (t, len(v), fname)
+        st_stat = U32.unpack(v)[0]
+        print("==> {:s} {:s}".format(stat.filemode(st_stat), os.path.join(*tree, fname)), end="")
+        fmt, mode = stat.S_IFMT(st_stat), stat.S_IMODE(st_stat)
+
+        if fmt == stat.S_IFDIR:
+            tree.append(fname)
+            mksubdir(prefix, tree)  # mode is ignored as one needs +w to create stuff :-)
+        elif fmt in (stat.S_IFREG, stat.S_IFLNK):
+            t, v = next(it)
+            with opensub(prefix, tree + [fname], "wb") as dfd:
+                while t == DATA:
+                    if fmt == stat.S_IFLNK:
+                        dfd.write(b"linkto: ")
+                    dfd.write(v)
+                    t, v = next(it)
+            assert t == END and len(v) in (0, U32.size), (t, len(v))
+            if len(v) == U32.size:
+                err = U32.unpack(v)[0]
+                print(" !!!! errno={:d} (maybe {:s})".format(err, errno.errorcode.get(err)), end="")
+        else:
+            raise NotImplementedError("Unsupported S_IF*", fmt)
+        print("")
+
+
+def main():
+    if len(sys.argv) == 3:
+        dir = sys.argv[2]
+    elif len(sys.argv) == 2:
+        dir = sys.argv[1] + "_contents"
+    else:
+        raise Exception("Usage: {:s} <supout.rif> [output_folder]".format(sys.argv[0]))
+
+    if not os.access(sys.argv[1], os.R_OK):
+        raise Exception("Can't read file " + sys.argv[1])
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+    dir = os.path.realpath(dir)
+    if not os.access(dir, os.W_OK):
+        raise Exception("Directory " + dir + " not writeable")
+    if os.listdir(dir) != []:
+        raise Exception("Directory " + dir + " not empty")
+
+    with open(sys.argv[1], "r") as supout:
+        sections = (
+            supout.read()
+            .replace("--END ROUTEROS SUPOUT SECTION", "")
+            .split("--BEGIN ROUTEROS SUPOUT SECTION")
+        )
+        i = 0
+        for sect in sections:
+            sect = "".join(sect.strip().split()).replace("=", "A")
+            if not sect:
+                continue
+            i += 1
+            secraw = tribit(base64.b64decode(sect))
+            name, blob = secraw.split(b"\x00", 1)
+            name = name.decode("ascii")
+            print("{:02d} {:6.1f} KiB(z) {:25s}".format(i, len(blob) / 1024, name), end="")
+            blob = zlib.decompress(blob)
+            oname = "{:02d}_{:s}".format(i, re.sub("[^-._a-zA-Z0-9]", "#", name))
+            print(" -> {:6.1f} KiB(raw) {:s}".format(len(blob) / 1024, oname), end="")
+            ofull = os.path.join(dir, oname)
+            with opensub(dir, (oname,), "wb") as fo:
+                fo.write(blob)
+            if blob.startswith(b"\4\4\0\0\0\2\0\0\0"):
+                print(", archive{LE}")
+                parse_ar(ofull, blob, U32LE)
+            elif blob.startswith(b"\4\0\0\0\4\0\0\0\2"):
+                print(", archive{BE}")
+                parse_ar(ofull, blob, U32BE)
+            else:
+                print("")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I've tested the patch with a few supout.rif files I had (ARM, ARM64, SMIPS) — the updated script decodes `/proc` data correctly.

Thanks for your awesome work!